### PR TITLE
Remove qemu package (it's just a dummy)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -24,7 +24,7 @@ runs:
     - name: Install packages
       uses: ConorMacBride/install-package@v1
       with:
-        apt: podman qemu qemu-user-static
+        apt: podman qemu-user-static
     - name: Setup
       shell: bash
       run: |


### PR DESCRIPTION
The `qemu` package has been removed from the ubuntu noble repositories so trying to run this action on `ubuntu-24.04` fails. Even on ubuntu jammy and ubuntu focal it's just a dummy package so it's safe to remove:

https://packages.ubuntu.com/jammy/qemu
https://packages.ubuntu.com/focal/qemu