### PR TITLE
Remove ConorMacBride/install-package dependency

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,9 +22,10 @@ runs:
   using: composite
   steps:
     - name: Install packages
-      uses: ConorMacBride/install-package@v1
-      with:
-        apt: podman qemu-user-static
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y podman qemu-user-static
+      shell: bash
     - name: Setup
       shell: bash
       run: |


### PR DESCRIPTION
We only support linux, so we can just call apt-get directly.

Closes #11 