### PR TITLE
Support initial_delay parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ jobs:
       with:
         container: ${{ matrix.job.container }}
         arch: ${{ matrix.job.arch }}
+        initial_delay: 30s
 
     - name: Setup Shell Wrapper
       uses: sandervocke/setup-shell-wrapper@v1

--- a/action.yml
+++ b/action.yml
@@ -17,6 +17,10 @@ inputs:
   podman_args:
     description: >
       Additional arguments to podman.
+  initial_delay:
+    description: >
+      Time to wait for pod to be available, e.g., 500ms, 30s, 5m.
+    default: 5m
 
 runs:
   using: composite
@@ -49,7 +53,7 @@ runs:
       with:
         run: $PODMAN_CMD
         wait-on: ${{ github.action_path }}/container_cid
-        wait-for: 5m
+        wait-for: ${{ inputs.initial_delay }}
         log-output-resume: true
     - name: Get CID
       shell: bash


### PR DESCRIPTION
This makes the wait-for argument of JarvusInnovations_background-action configurable.

initial_delay is used because other inputs are underscored, so this avoids wait-for/wait_for confusion with the action it calls.

The motivation is that my use case comes up in something more like a second or two. The initial delay was confusing--the workload appeared just stuck--but the current value is left as the input default.